### PR TITLE
Add support for pickling affine.Affine() instances.

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -434,6 +434,13 @@ class Affine(
 
     __hash__ = tuple.__hash__  # hash is not inherited in Py 3
 
+    def __getnewargs__(self):
+        # Required for unpickling.
+        # Normal unpickling creates a situation where __new__ receives all 9
+        # elements rather than the 6 that are required for the constructor.
+        # This method ensures that only the 6 are provided.
+        return self.a, self.b, self.c, self.d, self.e, self.f
+
 
 identity = Affine(1, 0, 0, 0, 1, 0)
 """The identity transform"""

--- a/affine/tests/test_pickle.py
+++ b/affine/tests/test_pickle.py
@@ -1,0 +1,30 @@
+"""
+Validate that instances of `affine.Affine()` can be pickled and unpickled.
+"""
+
+
+import pickle
+from multiprocessing import Pool
+
+import affine
+
+
+def test_pickle():
+    a = affine.Affine(1, 2, 3, 4, 5, 6)
+    assert pickle.loads(pickle.dumps(a)) == a
+
+
+def _mp_proc(x):
+    # A helper function - needed for test_with_multiprocessing()
+    # Can't be defined inside the test because multiprocessing needs
+    # everything to be in __main__
+    assert isinstance(x, affine.Affine)
+    return x
+
+
+def test_with_multiprocessing():
+    a1 = affine.Affine(1, 2, 3, 4, 5, 6)
+    a2 = affine.Affine(6, 5, 4, 3, 2, 1)
+    results = Pool(2).map(_mp_proc, [a1, a2])
+    for expected, actual in zip([a1, a2], results):
+        assert expected == actual


### PR DESCRIPTION
Closes #13.

Implemented [`__getnewargs__()`](https://docs.python.org/2/library/pickle.html#object.__getnewargs__) so that `__new__()` only received the first 6 elements.