### PR TITLE
move EPSILON to class property

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -49,25 +49,6 @@ __all__ = ['Affine']
 __author__ = "Sean Gillies"
 __version__ = "1.2.0"
 
-EPSILON = 1e-5
-EPSILON2 = EPSILON ** 2
-
-
-def set_epsilon(epsilon):
-    """Set the global absolute error value and rounding limit for approximate
-    floating point comparison operations. This value is accessible via the
-    :attr:`planar.EPSILON` global variable.
-
-    The default value of ``0.00001`` is suitable for values
-    that are in the "countable range". You may need a larger
-    epsilon when using large absolute values, and a smaller value
-    for very small values close to zero. Otherwise approximate
-    comparison operations will not behave as expected.
-    """
-    global EPSILON, EPSILON2
-    EPSILON = float(epsilon)
-    EPSILON2 = EPSILON ** 2
-
 
 class TransformNotInvertibleError(Exception):
     """The transform could not be inverted"""
@@ -90,24 +71,6 @@ else:  # pragma: no cover
         """Assert that a and b are unorderable"""
         raise TypeError("unorderable types: %s and %s"
             % (type(a).__name__, type(b).__name__))
-
-
-def cached_property(func):
-    """Special property decorator that caches the computed
-    property value in the object's instance dict the first
-    time it is accessed.
-    """
-    name = func.__name__
-    doc = func.__doc__
-
-    def getter(self, name=name):
-        try:
-            return self.__dict__[name]
-        except KeyError:
-            self.__dict__[name] = value = func(self)
-            return value
-    getter.func_name = name
-    return property(getter, doc=doc)
 
 
 def cos_sin_deg(deg):
@@ -150,6 +113,17 @@ class Affine(
         else:
             raise TypeError(
                 "Expected 6 coefficients, found %d" % len(members))
+
+    """Set the absolute error value and rounding limit for approximate
+    floating point comparison operations.
+
+    The default value of ``0.00001`` is suitable for values
+    that are in the "countable range". You may need a larger
+    epsilon when using large absolute values, and a smaller value
+    for very small values close to zero. Otherwise approximate
+    comparison operations will not behave as expected.
+    """
+    EPSILON = 1e-5
 
     @classmethod
     def from_gdal(cls, c, a, b, f, d, e):
@@ -274,7 +248,7 @@ class Affine(
         """Alias for 'f'"""
         return self.f
 
-    @cached_property
+    @property
     def determinant(self):
         """The determinant of the transform matrix. This value
         is equal to the area scaling factor when the transform
@@ -283,33 +257,33 @@ class Affine(
         a, b, c, d, e, f, g, h, i = self
         return a * e - b * d
 
-    @cached_property
+    @property
     def is_identity(self):
         """True if this transform equals the identity matrix,
         within rounding limits.
         """
         return self is identity or self.almost_equals(identity)
 
-    @cached_property
+    @property
     def is_rectilinear(self):
         """True if the transform is rectilinear, i.e., whether a shape would
         remain axis-aligned, within rounding limits, after applying the
         transform.
         """
         a, b, c, d, e, f, g, h, i = self
-        return ((abs(a) < EPSILON and abs(e) < EPSILON)
-            or (abs(d) < EPSILON and abs(b) < EPSILON))
+        return ((abs(a) < self.EPSILON and abs(e) < self.EPSILON)
+            or (abs(d) < self.EPSILON and abs(b) < self.EPSILON))
 
-    @cached_property
+    @property
     def is_conformal(self):
         """True if the transform is conformal, i.e., if angles between points
         are preserved after applying the transform, within rounding limits.
         This implies that the transform has no effective shear.
         """
         a, b, c, d, e, f, g, h, i = self
-        return abs(a * b + d * e) < EPSILON
+        return abs(a * b + d * e) < self.EPSILON
 
-    @cached_property
+    @property
     def is_orthonormal(self):
         """True if the transform is orthonormal, which means that the
         transform represents a rigid motion, which has no effective scaling or
@@ -319,16 +293,16 @@ class Affine(
         """
         a, b, c, d, e, f, g, h, i = self
         return (self.is_conformal
-            and abs(1.0 - (a * a + d * d)) < EPSILON
-            and abs(1.0 - (b * b + e * e)) < EPSILON)
+            and abs(1.0 - (a * a + d * d)) < self.EPSILON
+            and abs(1.0 - (b * b + e * e)) < self.EPSILON)
 
-    @cached_property
+    @property
     def is_degenerate(self):
         """True if this transform is degenerate, which means that it will
         collapse a shape to an effective area of zero. Degenerate transforms
         cannot be inverted.
         """
-        return abs(self.determinant) < EPSILON
+        return abs(self.determinant) < self.EPSILON
 
     @property
     def column_vectors(self):
@@ -342,10 +316,10 @@ class Affine(
         :param other: Transform being compared.
         :type other: Affine
         :return: True if absolute difference between each element
-            of each respective transform matrix < ``EPSILON``.
+            of each respective transform matrix < ``self.EPSILON``.
         """
         for i in (0, 1, 2, 3, 4, 5):
-            if abs(self[i] - other[i]) >= EPSILON:
+            if abs(self[i] - other[i]) >= self.EPSILON:
                 return False
         return True
 

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -288,7 +288,6 @@ class PyAffineTestCase(unittest.TestCase):
         assert not Affine.shear(4, -1).is_orthonormal
 
     def test_is_degenerate(self):
-        from affine import EPSILON
         assert not Affine.identity().is_degenerate
         assert not Affine.translation(2, -1).is_degenerate
         assert not Affine.shear(0, -22.5).is_degenerate
@@ -299,7 +298,7 @@ class PyAffineTestCase(unittest.TestCase):
         assert Affine.scale(0, 300).is_degenerate
         assert Affine.scale(0).is_degenerate
         assert Affine.scale(0).is_degenerate
-        assert Affine.scale(EPSILON).is_degenerate
+        assert Affine.scale(Affine.identity().EPSILON).is_degenerate
 
     def test_column_vectors(self):
         a, b, c = Affine(2, 3, 4, 5, 6, 7).column_vectors
@@ -311,7 +310,7 @@ class PyAffineTestCase(unittest.TestCase):
         assert_equal(c, (4, 7))
 
     def test_almost_equals(self):
-        from affine import EPSILON
+        EPSILON = Affine.identity().EPSILON
         assert EPSILON != 0, EPSILON
         E = EPSILON * 0.5
         t = Affine(1.0, E, 0, -E, 1.0 + E, E)
@@ -404,18 +403,6 @@ class PyAffineTestCase(unittest.TestCase):
         from affine import TransformNotInvertibleError
         t = Affine.scale(0)
         self.assertRaises(TransformNotInvertibleError, lambda: ~t)
-
-    def test_set_epsilon(self):
-        import affine
-
-        old_epsilon = affine.EPSILON
-
-        try:
-            affine.set_epsilon(123)
-            assert_equal(123, affine.EPSILON)
-            assert_equal(123 * 123, affine.EPSILON2)
-        finally:
-            affine.set_epsilon(old_epsilon)
 
     @raises(TypeError)
     def test_bad_type_world(self):


### PR DESCRIPTION
This PR moves the EPSILON from a module-level global to a class property. Resolves #18 

In order to avoid managing cache invalidation, I removed the concept of `cached_properties`. Most of those calculations take < 1/2 μs so I didn't see any performance reason for taking on that complexity. For example, the `determinant` property takes 449ns to calculate and 300ns to lookup from the cache. 

Also removed the EPSILON2 global as it wasn't being used anywhere. 

```python
>>> from affine import Affine
>>> a = Affine(0.000003, 0, 1000, 0, -0.000003, 1000)
>>> a.is_degenerate
True
>>> a.EPSILON
1e-05
>>> a.determinant
-9.000000000000001e-12
>>> b = Affine(0.000003, 0, 1000, 0, -0.000003, 1000)
>>> b.is_degenerate
True
>>> a.EPSILON = a.determinant * 0.1
>>> a.is_degenerate
False
>>> b.is_degenerate  # other instances are unaffected
True
```

I'm not fully aware of the history of the codebase and removing the global EPSILON might be a breaking change. I'm not sold on this implementation, just a first cut.