### PR TITLE
Fixed a bug in __mul__ 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Matrices can be created by passing the values ``a, b, c, d, e, f`` to the
 .. code-block:: pycon
 
   >>> from affine import Affine
-  >>> Affine.identity()
+  >>> Affine.identity() 
   Affine(1.0, 0.0, 0.0,
          0.0, 1.0, 0.0)
   >>> Affine.translation(1.0, 5.0)
@@ -55,7 +55,7 @@ coordinates ``(x', y')``.
   >>> Affine.translation(1.0, 5.0) * (1.0, 1.0)
   (2.0, 6.0)
   >>> Affine.rotation(45.0) * (1.0, 1.0)
-  (1.1102230246251565e-16, 1.414213562373095)
+  (1.414213562373095, 1.1102230246251565e-16)
 
 They may also be multiplied together to combine transformations.
 

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -237,13 +237,13 @@ class Affine(
         if pivot is None:
             return tuple.__new__(cls,
                 (ca, sa, 0.0,
-                -sa, ca, 0.0,
+                 -sa, ca, 0.0,
                  0.0, 0.0, 1.0))
         else:
             px, py = pivot
             return tuple.__new__(cls,
-                (ca, sa, px - px * ca + py * sa,
-                -sa, ca, py - px * sa - py * ca,
+                (ca, sa, px - px * ca - py * sa,
+                 -sa, ca, py + px * sa - py * ca,
                  0.0, 0.0, 1.0))
 
     def __str__(self):
@@ -385,7 +385,7 @@ class Affine(
                 vx, vy = other
             except Exception:
                 return NotImplemented
-            return (vx * sa + vy * sd + sc, vx * sb + vy * se + sf)
+            return (vx * sa + vy * sb + sc, vx * sd + vy * se + sf)
 
     def __rmul__(self, other):
         # We should not be called if other is an affine instance

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -175,16 +175,16 @@ class PyAffineTestCase(unittest.TestCase):
         assert_equal(
             tuple(rot),
             (c, s, 0,
-            -s, c, 0,
-             0, 0, 1))
+             -s,  c, 0,
+             0,  0, 1))
         rot = Affine.rotation(337)
         r = math.radians(337)
         s, c = math.sin(r), math.cos(r)
         seq_almost_equal(
             tuple(rot),
             (c, s, 0,
-            -s, c, 0,
-             0, 0, 1))
+             -s,  c, 0,
+             0,  0, 1))
         assert_equal(tuple(Affine.rotation(0)), tuple(Affine.identity()))
 
     def test_rotation_constructor_quadrants(self):
@@ -196,23 +196,23 @@ class PyAffineTestCase(unittest.TestCase):
         assert_equal(
             tuple(Affine.rotation(90)),
             (0, 1, 0,
-            -1, 0, 0,
-             0, 0, 1))
+             -1,  0, 0,
+             0,  0, 1))
         assert_equal(
             tuple(Affine.rotation(180)),
             (-1,  0, 0,
-              0, -1, 0,
-              0,  0, 1))
+             0, -1, 0,
+             0,  0, 1))
         assert_equal(
             tuple(Affine.rotation(-180)),
             (-1,  0, 0,
-              0, -1, 0,
-              0,  0, 1))
+             0, -1, 0,
+             0,  0, 1))
         assert_equal(
             tuple(Affine.rotation(270)),
             (0, -1, 0,
-             1,  0, 0,
-             0,  0, 1))
+             1, 0, 0,
+             0, 0, 1))
         assert_equal(
             tuple(Affine.rotation(-90)),
             (0, -1, 0,
@@ -226,27 +226,23 @@ class PyAffineTestCase(unittest.TestCase):
         assert_equal(
             tuple(Affine.rotation(450)),
             (0, 1, 0,
-            -1, 0, 0,
+             -1, 0, 0,
              0, 0, 1))
         assert_equal(
             tuple(Affine.rotation(-450)),
             (0, -1, 0,
-             1,  0, 0,
-             0,  0, 1))
+             1, 0, 0,
+             0, 0, 1))
 
     def test_rotation_constructor_with_pivot(self):
         assert_equal(tuple(Affine.rotation(60)),
-            tuple(Affine.rotation(60, pivot=(0, 0))))
-        rot = Affine.rotation(27, pivot=(2, -4))
-        r = math.radians(27)
-        s, c = math.sin(r), math.cos(r)
-        assert_equal(
-            tuple(rot),
-            (c, s, 2 - 2 * c - 4 * s,
-            -s, c, -4 - 2 * s + 4 * c,
-             0, 0, 1))
+                     tuple(Affine.rotation(60, pivot=(0, 0))))
         assert_equal(tuple(Affine.rotation(0, (-3, 2))),
                      tuple(Affine.identity()))
+        rot_pivot = Affine.rotation(27, pivot=(2, -4))
+        trans_rot_trans = (Affine.translation(2, -4) * Affine.rotation(27) *
+                           Affine.translation(-2, 4))
+        seq_almost_equal(tuple(rot_pivot), tuple(trans_rot_trans))
 
     @raises(TypeError)
     def test_rotation_contructor_wrong_arg_types(self):
@@ -362,6 +358,26 @@ class PyAffineTestCase(unittest.TestCase):
         t = Affine.scale(3, 5) * Affine.scale(2)
         seq_almost_equal(t, Affine.scale(6, 10))
 
+    def test_mul_vector(self):
+        seq_almost_equal(Affine.rotation(45.) * (1., 1.), (math.sqrt(2.), 0.))
+
+    def test_associative(self):
+        point = (12, 5)
+        trans = Affine.translation(-10., -5.)
+        rot90 = Affine.rotation(90.)
+        result1 = rot90 * (trans * point)
+        result2 = (rot90 * trans) * point
+        seq_almost_equal(result1, (0., -2.))
+        seq_almost_equal(result1, result2)
+
+    def test_roundtrip(self):
+        point = (12, 5)
+        trans = Affine.translation(3, 4)
+        rot37 = Affine.rotation(37.)
+        point_prime = (trans * rot37) * point
+        roundtrip_point = ~(trans * rot37) * point_prime
+        seq_almost_equal(point, roundtrip_point)
+        
     def test_itransform(self):
         pts = [(4, 1), (-1, 0), (3, 2)]
         r = Affine.scale(-2).itransform(pts)


### PR DESCRIPTION
I noticed that composition of transformations doesn't work, at least some of the time. Here's an example:

```
In [1]: import affine            

In [2]: affine.__version__
Out[2]: '1.2.0'

In [3]: from affine import Affine

In [4]: Affine.rotation(90.) * (Affine.translation(-10., -5.) * (12, 5))      
Out[4]: (0.0, 2.0)

In [5]: (Affine.rotation(90.) * Affine.translation(-10., -5.)) * (12, 5)
Out[5]: (-10.0, 22.0)
```

I think the problem is due to sign flips in the `__mul__` method. I've corrected the sign flips where necessary and added some additional test coverage. All tests pass.

However, it's possible that I'm simply not understanding some nuance of raster coordinates versus "standard" Cartesian coordinates.