### PR TITLE
Fix rotation matrix and __mul__ op

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -236,14 +236,14 @@ class Affine(
         ca, sa = cos_sin_deg(angle)
         if pivot is None:
             return tuple.__new__(cls,
-                (ca, sa, 0.0,
-                -sa, ca, 0.0,
+                (ca, -sa, 0.0,
+                 sa, ca, 0.0,
                  0.0, 0.0, 1.0))
         else:
             px, py = pivot
             return tuple.__new__(cls,
-                (ca, sa, px - px * ca + py * sa,
-                -sa, ca, py - px * sa - py * ca,
+                (ca, -sa, px - px * ca + py * sa,
+                 sa, ca, py - px * sa - py * ca,
                  0.0, 0.0, 1.0))
 
     def __str__(self):
@@ -385,7 +385,7 @@ class Affine(
                 vx, vy = other
             except Exception:
                 return NotImplemented
-            return (vx * sa + vy * sd + sc, vx * sb + vy * se + sf)
+            return (vx * sa + vy * sb + sc, vx * sd + vy * se + sf)
 
     def __rmul__(self, other):
         # We should not be called if other is an affine instance

--- a/affine/tests/test_rotation.py
+++ b/affine/tests/test_rotation.py
@@ -1,4 +1,4 @@
-from math import sqrt
+import math
 
 from affine import Affine
 
@@ -23,5 +23,31 @@ def test_rotation_angle():
         0----------
     """
     x, y = Affine.rotation(45.0) * (1.0, 0.0)
-    assert round(x, 14) == round(sqrt(2.0) / 2.0, 14)
-    assert round(y, 14) == round(sqrt(2.0) / 2.0, 14)
+    assert round(x, 14) == round(math.sqrt(2.0) / 2.0, 14)
+    assert round(y, 14) == round(math.sqrt(2.0) / 2.0, 14)
+
+
+def test_rotation_matrix():
+    """A rotation matrix has expected elements
+
+    | cos(a) -sin(a) |
+    | sin(a)  cos(a) |
+
+    """
+    rot = Affine.rotation(90.0)
+    assert round(rot.a, 15) == round(math.cos(math.pi/2.0), 15)
+    assert round(rot.b, 15) == round(-math.sin(math.pi/2.0), 15)
+    assert rot.c == 0.0
+    assert round(rot.d, 15) == round(math.sin(math.pi/2.0), 15)
+    assert round(rot.e, 15) == round(math.cos(math.pi/2.0), 15)
+    assert rot.f == 0.0
+
+
+def test_rotation_matrix_pivot():
+    """A rotation matrix with pivot has expected elements"""
+    rot = Affine.rotation(90.0, pivot=(1.0, 1.0))
+    exp = (Affine.translation(1.0, 1.0)
+           * Affine.rotation(90.0)
+           * Affine.translation(-1.0, -1.0))
+    for r, e in zip(rot, exp):
+        assert round(r, 15) == round(e, 15)

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -174,16 +174,16 @@ class PyAffineTestCase(unittest.TestCase):
         s, c = math.sin(r), math.cos(r)
         assert_equal(
             tuple(rot),
-            (c, s, 0,
-            -s, c, 0,
+            (c, -s, 0,
+             s, c, 0,
              0, 0, 1))
         rot = Affine.rotation(337)
         r = math.radians(337)
         s, c = math.sin(r), math.cos(r)
         seq_almost_equal(
             tuple(rot),
-            (c, s, 0,
-            -s, c, 0,
+            (c, -s, 0,
+             s, c, 0,
              0, 0, 1))
         assert_equal(tuple(Affine.rotation(0)), tuple(Affine.identity()))
 
@@ -195,8 +195,8 @@ class PyAffineTestCase(unittest.TestCase):
              0, 0, 1))
         assert_equal(
             tuple(Affine.rotation(90)),
-            (0, 1, 0,
-            -1, 0, 0,
+            (0, -1, 0,
+             1, 0, 0,
              0, 0, 1))
         assert_equal(
             tuple(Affine.rotation(180)),
@@ -210,13 +210,13 @@ class PyAffineTestCase(unittest.TestCase):
               0,  0, 1))
         assert_equal(
             tuple(Affine.rotation(270)),
-            (0, -1, 0,
-             1,  0, 0,
+            (0, 1, 0,
+             -1,  0, 0,
              0,  0, 1))
         assert_equal(
             tuple(Affine.rotation(-90)),
-            (0, -1, 0,
-             1,  0, 0,
+            (0, 1, 0,
+             -1,  0, 0,
              0,  0, 1))
         assert_equal(
             tuple(Affine.rotation(360)),
@@ -225,13 +225,13 @@ class PyAffineTestCase(unittest.TestCase):
              0, 0, 1))
         assert_equal(
             tuple(Affine.rotation(450)),
-            (0, 1, 0,
-            -1, 0, 0,
+            (0, -1, 0,
+             1, 0, 0,
              0, 0, 1))
         assert_equal(
             tuple(Affine.rotation(-450)),
-            (0, -1, 0,
-             1,  0, 0,
+            (0, 1, 0,
+             -1,  0, 0,
              0,  0, 1))
 
     def test_rotation_constructor_with_pivot(self):
@@ -242,8 +242,8 @@ class PyAffineTestCase(unittest.TestCase):
         s, c = math.sin(r), math.cos(r)
         assert_equal(
             tuple(rot),
-            (c, s, 2 - 2 * c - 4 * s,
-            -s, c, -4 - 2 * s + 4 * c,
+            (c, -s, 2 - 2 * c - 4 * s,
+             s, c, -4 - 2 * s + 4 * c,
              0, 0, 1))
         assert_equal(tuple(Affine.rotation(0, (-3, 2))),
                      tuple(Affine.identity()))


### PR DESCRIPTION
The dot product of a rotation matrix and vector was right, but separately these were wrong.