### PR TITLE
Add eccentricity and rotation angle computation

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -285,6 +285,25 @@ class Affine(
         a, b, c, d, e, f, g, h, i = self
         return a * e - b * d
 
+    @cached_property
+    def scaling(self):
+        """The scaling factors of the transformation.
+
+        XXX
+        """
+        a, b, c, d, e, f, g, h, i = self
+        return a, e
+
+    @cached_property
+    def eccentricity(self):
+        """The eccentricity of the affine transformation.
+
+        This value represents the eccentricity of an ellipse under
+        this affine transformation.
+        """
+        sx, sy = self.scaling
+        return math.sqrt(abs(sx ** 2 - sy ** 2)) / max(sx, sy)
+
     @property
     def is_identity(self):
         """True if this transform equals the identity matrix,

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -139,10 +139,10 @@ class Affine(
     """
     precision = EPSILON
 
-    def __new__(self, *members):
+    def __new__(cls, *members):
         if len(members) == 6:
             mat3x3 = [x * 1.0 for x in members] + [0.0, 0.0, 1.0]
-            return tuple.__new__(Affine, mat3x3)
+            return tuple.__new__(cls, mat3x3)
         else:
             raise TypeError(
                 "Expected 6 coefficients, found %d" % len(members))
@@ -441,7 +441,7 @@ class Affine(
         if isinstance(other, Affine):
             oa, ob, oc, od, oe, of, _, _, _ = other
             return tuple.__new__(
-                Affine,
+                self.__class__,
                 (sa * oa + sb * od, sa * ob + sb * oe, sa * oc + sb * of + sc,
                  sd * oa + se * od, sd * ob + se * oe, sd * oc + se * of + sf,
                  0.0, 0.0, 1.0))
@@ -493,7 +493,7 @@ class Affine(
         rd = -sd * idet
         re = sa * idet
         return tuple.__new__(
-            Affine,
+            self.__class__,
             (ra, rb, -sc * ra - sf * rb,
              rd, re, -sc * rd - sf * re,
              0.0, 0.0, 1.0))

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -302,7 +302,7 @@ class Affine(
         Raises NotImplementedError for improper transformations.
         """
         if self.is_proper or self.is_degenerate:
-            U, s, V = self._decompose()
+            U, s, _ = self._decompose()
             sx, sy = np.diag(U @ np.diag(s) @ U.T)
             return sx, sy
         else:
@@ -317,6 +317,21 @@ class Affine(
         """
         sx, sy = self.scaling
         return math.sqrt(abs(sx ** 2 - sy ** 2)) / max(sx, sy)
+
+    @property
+    def rotation_angle(self):
+        """The rotation angle of the affine transformation.
+
+        XXX
+
+        Raises NotImplementedError for improper transformations.
+        """
+        if self.is_proper or self.is_degenerate:
+            U, _, V = self._decompose()
+            y, x = (U @ V)[-1]
+            return np.arctan2(y, x)
+        else:
+            raise NotImplementedError
 
     @property
     def is_identity(self):

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -44,9 +44,6 @@ from __future__ import division
 from collections import namedtuple
 import math
 
-import numpy as np
-from numpy.linalg import svd
-
 
 __all__ = ['Affine']
 __author__ = "Sean Gillies"
@@ -278,10 +275,6 @@ class Affine(
         """Alias for 'f'"""
         return self.f
 
-    def _decompose(self):
-        a, b, c, d, e, f, g, h, i = self
-        return svd(np.array([[a, b], [d, e]]))
-
     @cached_property
     def determinant(self):
         """The determinant of the transform matrix.
@@ -330,14 +323,16 @@ class Affine(
     def rotation_angle(self):
         """The rotation angle of the affine transformation.
 
-        XXX
+        This is the rotation angle of the affine transformation, assuming
+        it is in the form M = R S, where R is a rotation and S is a scaling.
 
         Raises NotImplementedError for improper transformations.
         """
+        a, b, _, c, d, _, _, _, _ = self
         if self.is_proper or self.is_degenerate:
-            U, _, V = self._decompose()
-            y, x = (U @ V)[-1]
-            return np.arctan2(y, x)
+            l1, _ = self._scaling
+            y, x = c / l1, a / l1
+            return math.atan2(y, x)
         else:
             raise NotImplementedError
 

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -47,7 +47,7 @@ import math
 
 __all__ = ['Affine']
 __author__ = "Sean Gillies"
-__version__ = "2.0.0.post1"
+__version__ = "2.1.dev0"
 
 EPSILON = 1e-5
 

--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -289,7 +289,8 @@ class Affine(
     def scaling(self):
         """The scaling factors of the transformation.
 
-        XXX
+        This tuple represents the scaling factors of the
+        transformation.
         """
         a, b, c, d, e, f, g, h, i = self
         return a, e

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -545,7 +545,7 @@ def test_eccentricity_complex():
 
 @raises(NotImplementedError)
 def test_eccentricity_improper():
-    assert_equal(Affine.scale(-1, 1).eccentricity, -0.0)
+    Affine.scale(-1, 1).eccentricity
 
 
 def test_rotation_angle():
@@ -555,6 +555,11 @@ def test_rotation_angle():
     assert_almost_equal(Affine.translation(32, -47).rotation_angle, 0.0)
     assert_almost_equal(Affine.rotation(30).rotation_angle, 30 * math.pi / 180)
     assert_almost_equal(Affine.rotation(-150).rotation_angle, -150 * math.pi / 180)
+
+
+@raises(NotImplementedError)
+def test_rotation_improper():
+    Affine.scale(-1, 1).rotation_angle
 
 
 if __name__ == '__main__':

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -523,10 +523,18 @@ def test_scaling():
     assert_equal(Affine.scale(0).scaling, (0, 0))
     assert_equal(Affine.scale(5, 1).scaling, (5, 1))
     assert_equal(Affine.scale(1, 3).scaling, (1, 3))
+
+    assert_almost_equal(Affine.translation(32, -47).scaling[0], 1)
+    assert_almost_equal(Affine.translation(32, -47).scaling[1], 1)
+
+    assert_almost_equal(Affine.rotation(77).scaling[0], 1)
+    assert_almost_equal(Affine.rotation(77).scaling[1], 1)
+
+
+@raises(NotImplementedError)
+def test_scaling_improper():
     assert_equal(Affine.scale(-1, 1).scaling, (-1, 1))
     assert_equal(Affine.scale(-1, 0).scaling, (-1, 0))
-    assert_equal(Affine.translation(32, -47).scaling, (1, 1))
-    assert_equal(Affine.rotation(77).scaling, (1, 1))
 
 
 def test_eccentricity():
@@ -536,9 +544,13 @@ def test_eccentricity():
     assert_almost_equal(Affine.scale(2, 1).eccentricity, math.sqrt(3) / 2)
     assert_almost_equal(Affine.scale(2, 3).eccentricity, math.sqrt(5) / 3)
     assert_equal(Affine.scale(1, 0).eccentricity, 1.0)
-    assert_equal(Affine.scale(-1, 1).eccentricity, -0.0)
     assert_almost_equal(Affine.rotation(77).eccentricity, 0.0)
     assert_almost_equal(Affine.translation(32, -47).eccentricity, 0.0)
+
+
+@raises(NotImplementedError)
+def test_eccentricity_improper():
+    assert_equal(Affine.scale(-1, 1).eccentricity, -0.0)
 
 
 if __name__ == '__main__':

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -517,6 +517,18 @@ def test_roundtrip():
     seq_almost_equal(point, roundtrip_point)
 
 
+def test_eccentricity():
+    assert_equal(Affine.identity().eccentricity, 0.0)
+    assert_equal(Affine.scale(2).eccentricity, 0.0)
+    #assert_equal(Affine.scale(0).eccentricity, ?)
+    assert_almost_equal(Affine.scale(2, 1).eccentricity, math.sqrt(3) / 2)
+    assert_almost_equal(Affine.scale(2, 3).eccentricity, math.sqrt(5) / 3)
+    assert_equal(Affine.scale(1, 0).eccentricity, 1.0)
+    assert_equal(Affine.scale(-1, 1).eccentricity, -0.0)
+    assert_almost_equal(Affine.rotation(77).eccentricity, 0.0)
+    assert_almost_equal(Affine.translation(32, -47).eccentricity, 0.0)
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -517,6 +517,18 @@ def test_roundtrip():
     seq_almost_equal(point, roundtrip_point)
 
 
+def test_scaling():
+    assert_equal(Affine.identity().scaling, (1, 1))
+    assert_equal(Affine.scale(2).scaling, (2, 2))
+    assert_equal(Affine.scale(0).scaling, (0, 0))
+    assert_equal(Affine.scale(5, 1).scaling, (5, 1))
+    assert_equal(Affine.scale(1, 3).scaling, (1, 3))
+    assert_equal(Affine.scale(-1, 1).scaling, (-1, 1))
+    assert_equal(Affine.scale(-1, 0).scaling, (-1, 0))
+    assert_equal(Affine.translation(32, -47).scaling, (1, 1))
+    assert_equal(Affine.rotation(77).scaling, (1, 1))
+
+
 def test_eccentricity():
     assert_equal(Affine.identity().eccentricity, 0.0)
     assert_equal(Affine.scale(2).eccentricity, 0.0)

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -517,26 +517,6 @@ def test_roundtrip():
     seq_almost_equal(point, roundtrip_point)
 
 
-def test_scaling():
-    assert_equal(Affine.identity().scaling, (1, 1))
-    assert_equal(Affine.scale(2).scaling, (2, 2))
-    assert_equal(Affine.scale(0).scaling, (0, 0))
-    assert_equal(Affine.scale(5, 1).scaling, (5, 1))
-    assert_equal(Affine.scale(1, 3).scaling, (1, 3))
-
-    assert_almost_equal(Affine.translation(32, -47).scaling[0], 1)
-    assert_almost_equal(Affine.translation(32, -47).scaling[1], 1)
-
-    assert_almost_equal(Affine.rotation(77).scaling[0], 1)
-    assert_almost_equal(Affine.rotation(77).scaling[1], 1)
-
-
-@raises(NotImplementedError)
-def test_scaling_improper():
-    assert_equal(Affine.scale(-1, 1).scaling, (-1, 1))
-    assert_equal(Affine.scale(-1, 0).scaling, (-1, 0))
-
-
 def test_eccentricity():
     assert_equal(Affine.identity().eccentricity, 0.0)
     assert_equal(Affine.scale(2).eccentricity, 0.0)

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -568,6 +568,15 @@ def test_eccentricity_improper():
     assert_equal(Affine.scale(-1, 1).eccentricity, -0.0)
 
 
+def test_rotation_angle():
+    assert_equal(Affine.identity().rotation_angle, 0.0)
+    assert_equal(Affine.scale(2).rotation_angle, 0.0)
+    assert_equal(Affine.scale(2, 1).rotation_angle, 0.0)
+    assert_almost_equal(Affine.translation(32, -47).rotation_angle, 0.0)
+    assert_almost_equal(Affine.rotation(30).rotation_angle, 30 * math.pi / 180)
+    assert_almost_equal(Affine.rotation(-150).rotation_angle, -150 * math.pi / 180)
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -548,6 +548,21 @@ def test_eccentricity():
     assert_almost_equal(Affine.translation(32, -47).eccentricity, 0.0)
 
 
+def test_eccentricity_complex():
+    assert_almost_equal(
+        (Affine.scale(2, 3) * Affine.rotation(77)).eccentricity,
+        math.sqrt(5) / 3
+    )
+    assert_almost_equal(
+        (Affine.rotation(77) * Affine.scale(2, 3)).eccentricity,
+        math.sqrt(5) / 3
+    )
+    assert_almost_equal(
+        (Affine.translation(32, -47) * Affine.rotation(77) * Affine.scale(2, 3)).eccentricity,
+        math.sqrt(5) / 3
+    )
+
+
 @raises(NotImplementedError)
 def test_eccentricity_improper():
     assert_equal(Affine.scale(-1, 1).eccentricity, -0.0)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(name='affine',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
+      install_requires=["numpy"],
       extras_require = {'test':  ['pytest']}
       )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,5 @@ setup(name='affine',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=["numpy"],
       extras_require = {'test':  ['pytest']}
       )


### PR DESCRIPTION
I implemented the computation of the [eccentricity](https://en.wikipedia.org/wiki/Eccentricity_(mathematics)#Ellipses) of the affine transformation and the computation of the rotation angle of the afine transformations. We are only checking for proper or non-degenerate cases (i.e. no reflexion).

Besides, for easier testing I modified the Affine class so its methods respect subclasses. This is not strictly related to the added functionality and can be put into another pull request.

I first used NumPy for computing the singular values but then decided to remove the dependency and do it manually. I can squash those commits too.

Do the maintainters think this is a valuable addition to the library?

cc @slava-kerner @luciotorre