### PR TITLE
Add testing with Python 3.7 on xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-sudo: false
+dist: xenial
 language: python
 cache: pip
 python:
   - 2.7
   - 3.6
+  - 3.7
 install:
   - pip install -r requirements.txt
   - pip install .[test]

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,7 +3,7 @@ Authors
 
 - Sean Gillies <sean@mapbox.com>
 - Steven Ring <smr@southsky.com.au>
-- Mike Toews <mwtoews@gmail.com>
+- Mike Taves <mwtoews@gmail.com>
 - Kevin Wurster <wursterk@gmail.com>
 - Todd Small <todd_small@icloud.com>
 - Juan Luis Cano Rodríguez <juanlu@satellogic.com>

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py27,py36
+    py27,py36,py37
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
We can also drop py36 too.