### PR TITLE
Improve interoperability with shapely

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -311,6 +311,16 @@ class Affine(
         """
         return (self.c, self.a, self.b, self.f, self.d, self.e)
 
+    def to_shapely(self):
+        """Return an affine transformation matrix compatible with shapely
+
+        Shapely's affinity module expects an affine transformation matrix
+        in (a,b,d,e,xoff,yoff) order.
+
+        :rtype: tuple
+        """
+        return (self.a, self.b, self.d, self.e, self.xoff, self.yoff)
+
     @property
     def xoff(self):
         """Alias for 'c'"""

--- a/affine/tests/test_transform.py
+++ b/affine/tests/test_transform.py
@@ -128,8 +128,8 @@ class PyAffineTestCase(unittest.TestCase):
             (0, 1, 0,
              1, 0, 0,
              0, 0, 1)
-        assert (perm*perm).is_identity        
-        
+        assert (perm*perm).is_identity
+
     def test_translation_constructor(self):
         trans = Affine.translation(2, -5)
         assert isinstance(trans, Affine)
@@ -483,6 +483,11 @@ def test_gdal():
     assert t.e == -425.0
     assert tuple(t) == (425.0, 0.0, -237481.5, 0.0, -425.0, 237536.4, 0, 0, 1.0)
     assert t.to_gdal() == (-237481.5, 425.0, 0.0, 237536.4, 0.0, -425.0)
+
+
+def test_shapely():
+    t = Affine(425.0, 0.0, -237481.5, 0.0, -425.0, 237536.4)
+    assert t.to_shapely() == (425.0, 0.0, 0.0, -425, -237481.5, 237536.4)
 
 
 def test_imul_number():


### PR DESCRIPTION
- Add a new .to_shapely method to the Affine class that returns a tuple
in the order expected by shapely's affinity module
- Write simple unit test for the new method