### PR TITLE
Bumpy required version of pytest to at least 4.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     include_package_data=True,
     zip_safe=True,
-    extras_require={"test": ["pytest>=3.0", "pytest-cov", "pydocstyle",
+    extras_require={"test": ["pytest>=4.6", "pytest-cov", "pydocstyle",
                              "flake8", "coveralls"]},
 )


### PR DESCRIPTION
Bump pytest version to 4.6 as required by pytest-cov.