### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 dist: xenial
 language: python
+arch:
+  - amd64
+  - ppc64le
 cache: pip
 python:
   - 2.7
   - 3.6
   - 3.7
   - pypy3
+jobs:
+  exclude:
+   - arch: ppc64le
+     python: pypy3
 install:
   - pip install flake8 pydocstyle
   - pip install .[test]


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. Since ppc64le focal doesn't have pypy3 support, excluded only that.